### PR TITLE
Fix menu on 'virtual solution items'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+packages

--- a/VsShellContext/VsShellContext.csproj
+++ b/VsShellContext/VsShellContext.csproj
@@ -36,6 +36,11 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -58,7 +63,27 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.OLE.Interop" />
+    <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\EnvDTE.8.0.0\lib\net10\EnvDTE.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="EnvDTE80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\EnvDTE80.8.0.0\lib\net10\EnvDTE80.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.CoreUtility.15.0.26201\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6070\lib\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Framework.15.0.26201\lib\net45\Microsoft.VisualStudio.Shell.Framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Immutable.10.0.10.0.30319\lib\net40\Microsoft.VisualStudio.Shell.Immutable.10.0.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
@@ -66,23 +91,22 @@
     <Reference Include="Microsoft.VisualStudio.Shell.10.0">
       <Private>false</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" />
+    <Reference Include="Microsoft.VisualStudio.Shell.UI.Internal, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Microsoft.VisualStudio.Shell.UI.Internal.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Utilities.15.0.26201\lib\net45\Microsoft.VisualStudio.Utilities.dll</HintPath>
+    </Reference>
+    <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\stdole.7.0.3300\lib\net10\stdole.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
-  </ItemGroup>
-  <ItemGroup>
-    <COMReference Include="EnvDTE">
-      <Guid>{80CC9F66-E7D8-4DDD-85B6-D9E6CD0E93E2}</Guid>
-      <VersionMajor>8</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Guids.cs" />
@@ -111,6 +135,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/VsShellContext/VsShellContext.vsct
+++ b/VsShellContext/VsShellContext.vsct
@@ -50,6 +50,9 @@
       <Group guid="guidVsShellContextCmdSet" id="MyMenuGroup" priority="0x0001">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_PROJNODE" />
       </Group>
+      <Group guid="guidVsShellContextCmdSet" id="MyMenuGroup" priority="0x0001">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_EZDOCWINTAB" />
+      </Group>
     </Groups>
     
     <!--Buttons section. -->

--- a/VsShellContext/VsShellContextPackage.cs
+++ b/VsShellContext/VsShellContextPackage.cs
@@ -139,23 +139,23 @@ namespace Outstance.VsShellContext
             foreach (var hierarchyItem in selHierarchyItems)
             {
                 // Top-level project. See below for projects in folders.
-                var project = hierarchyItem.Object as Project;
-                if (project != null)
+                if (hierarchyItem.Object is Project project)
                 {
                     result.Add(project.FullName);
-                    continue;
                 }
-
-                var projectItem = hierarchyItem.Object as ProjectItem;
-                if (projectItem != null)
+                else if (hierarchyItem.Object is ProjectItem projectItem)
                 {
-                    // Somehow, projects inside a Solution Folder (i.e. "virtual" folder) gets wrapped inside another project item..
-                    if (projectItem.Object is Project)
-                        result.Add(((Project)projectItem.Object).FullName);
-                    else if (projectItem.Properties == null) // This is a solution item
-                        result.Add(projectItem.Name);
-                    else //This is a normal file.
+                    // Projects inside a Solution Folder (i.e. "virtual" folder) gets wrapped inside another project item.
+                    if (projectItem.Object is Project innerProject)
+                    {
+                        result.Add(innerProject.Object.FullName);
+                    }
+                    else
+                    {
+                        // Files in a Solution Folder (i.e. "virtual" folder) need to be re-looked up in the solution.
+                        projectItem = _dte.Solution.FindProjectItem(projectItem.Name);
                         result.Add(projectItem.Properties.Item("FullPath").Value.ToString());
+                    }
                 }
             }
             return result;

--- a/VsShellContext/VsShellContextPackage.cs
+++ b/VsShellContext/VsShellContextPackage.cs
@@ -152,6 +152,8 @@ namespace Outstance.VsShellContext
                     // Somehow, projects inside a Solution Folder (i.e. "virtual" folder) gets wrapped inside another project item..
                     if (projectItem.Object is Project)
                         result.Add(((Project)projectItem.Object).FullName);
+                    else if (projectItem.Properties == null) // This is a solution item
+                        result.Add(projectItem.Name);
                     else //This is a normal file.
                         result.Add(projectItem.Properties.Item("FullPath").Value.ToString());
                 }

--- a/VsShellContext/VsShellContextPackage.cs
+++ b/VsShellContext/VsShellContextPackage.cs
@@ -156,9 +156,7 @@ namespace Outstance.VsShellContext
                         }
                         else
                         {
-                            // Files in a Solution Folder (i.e. "virtual" folder) need to be re-looked up in the solution.
-                            projectItem = _dte.Solution.FindProjectItem(projectItem.Name);
-                            result.Add(projectItem.Properties.Item("FullPath").Value.ToString());
+                            result.Add(projectItem.FileNames[1]);
                         }
                     }
                 }

--- a/VsShellContext/VsShellContextPackage.cs
+++ b/VsShellContext/VsShellContextPackage.cs
@@ -10,7 +10,6 @@ using EnvDTE;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell;
-using System.Reflection;
 
 namespace Outstance.VsShellContext
 {

--- a/VsShellContext/VsShellContextPackage.cs
+++ b/VsShellContext/VsShellContextPackage.cs
@@ -10,6 +10,7 @@ using EnvDTE;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell;
+using System.Reflection;
 
 namespace Outstance.VsShellContext
 {
@@ -36,7 +37,7 @@ namespace Outstance.VsShellContext
     {
         private DTE _dte;
         private IVsMonitorSelection _monitorSelection;
-        private readonly Guid SolutionExplorerGuid = new Guid(EnvDTE.Constants.vsWindowKindSolutionExplorer);
+        private readonly Guid SolutionExplorerGuid = new Guid("{3AE79031-E1BC-11D0-8F78-00A0C9110057}");
         private const int DocumentFrame = 1;
 
         /// <summary>
@@ -129,7 +130,7 @@ namespace Outstance.VsShellContext
         private IList<string> PopulateFileNamesFromSolutionExplorer()
         {
             // TODO: (NP) Better null validation. For now just let them bubble up as exception.
-            var uiH = (UIHierarchy)_dte.Windows.Item(EnvDTE.Constants.vsWindowKindSolutionExplorer).Object;
+            var uiH = (UIHierarchy)_dte.Windows.Item("{3AE79031-E1BC-11D0-8F78-00A0C9110057}").Object;
             var selItems = uiH.SelectedItems as Array;
 
             var result = new List<string>();

--- a/VsShellContext/VsShellContextPackage.cs
+++ b/VsShellContext/VsShellContextPackage.cs
@@ -138,22 +138,28 @@ namespace Outstance.VsShellContext
             foreach (var hierarchyItem in selHierarchyItems)
             {
                 // Top-level project. See below for projects in folders.
-                if (hierarchyItem.Object is Project project)
+                var project = hierarchyItem.Object as Project;
+                if (project != null)
                 {
                     result.Add(project.FullName);
                 }
-                else if (hierarchyItem.Object is ProjectItem projectItem)
+                else
                 {
-                    // Projects inside a Solution Folder (i.e. "virtual" folder) gets wrapped inside another project item.
-                    if (projectItem.Object is Project innerProject)
+                    var projectItem = hierarchyItem.Object as ProjectItem;
+                    if (projectItem != null)
                     {
-                        result.Add(innerProject.Object.FullName);
-                    }
-                    else
-                    {
-                        // Files in a Solution Folder (i.e. "virtual" folder) need to be re-looked up in the solution.
-                        projectItem = _dte.Solution.FindProjectItem(projectItem.Name);
-                        result.Add(projectItem.Properties.Item("FullPath").Value.ToString());
+                        // Projects inside a Solution Folder (i.e. "virtual" folder) gets wrapped inside another project item.
+                        var innerProject = projectItem.Object as Project;
+                        if (innerProject != null)
+                        {
+                            result.Add(innerProject.Object.FullName);
+                        }
+                        else
+                        {
+                            // Files in a Solution Folder (i.e. "virtual" folder) need to be re-looked up in the solution.
+                            projectItem = _dte.Solution.FindProjectItem(projectItem.Name);
+                            result.Add(projectItem.Properties.Item("FullPath").Value.ToString());
+                        }
                     }
                 }
             }

--- a/VsShellContext/packages.config
+++ b/VsShellContext/packages.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EnvDTE" version="8.0.0" targetFramework="net45" />
+  <package id="EnvDTE80" version="8.0.0" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.CoreUtility" version="15.0.26201" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Shell.Framework" version="15.0.26201" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Shell.Immutable.10.0" version="10.0.30319" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Utilities" version="15.0.26201" targetFramework="net45" />
+  <package id="stdole" version="7.0.3300" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Fixes https://github.com/idealist1508/ShellContextMenuExtension/issues/2
The context menu now works on files inside virtual solution folders. To get this running on my machine, I needed to make changes to project references.